### PR TITLE
Sticky nav disabled on mobile devices.

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,7 +61,7 @@
 
       <div class="uk-grid" data-uk-grid-margin>
         <div class="uk-width-medium-1-4">
-          <div class="uk-panel uk-panel-box" data-uk-sticky="{top:35}">
+          <div class="uk-panel uk-panel-box" data-uk-sticky="{top:35, media: '(min-width:768px)'}">
             <ul class="uk-nav uk-nav-side" data-uk-scrollspy-nav="{closest:'li', smoothscroll:true}">
               <li class="uk-active"><a href="#introduction">Introduction</a></li>
               <li class="uk-nav-header">Algorithms</li>


### PR DESCRIPTION
On screen sizes less than 768px, sticky nav covers half the screen. This PR disables sticky nav on screen sizes less than 768px.
