### PR TITLE
update to shell-sort for specific h-sequence

### DIFF
--- a/index.html
+++ b/index.html
@@ -146,10 +146,10 @@
                   <td><code class="bigo-great">O(1)</code></td>
                 </tr>
                 <tr>
-                  <td><a href="http://en.wikipedia.org/wiki/Shellsort">Shell Sort</a></td>
+                  <td><a href="http://en.wikipedia.org/wiki/Shellsort">Shell Sort</a><a href="http://www.cs.wcupa.edu/rkline/ds/shell-comparison.html"><code>(h=2^k-1)</code></a></td>
                   <td><code class="bigo-ok">O(n log(n))</code></td>
-                  <td><code class="bigo-ok">-</code></td>
-                  <td><code class="bigo-ok">O(n log<sub>2</sub>(n))</code></td>
+                  <td><code class="bigo-ok">O(n<sup>1.25</sup>)</code> conjectured</td>
+                  <td><code class="bigo-ok">O(n<sup>(3/2)</sup>)</code></td>
                   <td><code class="bigo-great">O(1)</code></td>
                 </tr>
                 <tr>


### PR DESCRIPTION
shellsort needs reference to a specific h-sequence otherwise the complexity varies tremendously. So used the h-sequence that wikipedia cites in their table: http://www.cs.wcupa.edu/rkline/ds/shell-comparison.html.
